### PR TITLE
Fix CircleCI build by using compatible build-tools version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
         }
     }
     compileSdkVersion 25
-    buildToolsVersion "26.0.0"
+    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.example.srv_twry.studentcompanion"
         minSdkVersion 15


### PR DESCRIPTION
Fixes #11 

The CircleCI Docker image does not include the 26.0.0 build-tools:
See https://github.com/circleci/circleci-images/blob/master/android/Dockerfile.m4#L81-L85